### PR TITLE
Make LoginStore struct instead of enum

### DIFF
--- a/DemoApp/LoginDemo/Features/Login/LoginStore.swift
+++ b/DemoApp/LoginDemo/Features/Login/LoginStore.swift
@@ -12,7 +12,7 @@ import RxFeedback
 import RxSwift
 import RxCocoa
 
-enum LoginStore {
+struct LoginStore {
     struct Outputs<ViewModel, Navigation> {
         let viewDriver: Driver<ViewModel>
         let navigationDriver: Signal<Navigation>

--- a/Docs/sensor.md
+++ b/Docs/sensor.md
@@ -156,7 +156,7 @@ In the above figure, from the state **S2**, it moves to **S3** with a specific e
 Finally the following is a sample implementation of a Store for the above login feature.
 
 ```swift
-enum LoginStore {
+struct LoginStore {
     static func makeOutputs(inputs: LoginView.Outputs, alertInput: Signal<RxAlertResult>) ->
                            (viewOutputs: Driver<LoginView.Model>) {
         let inputEvents: Signal<Event> = Signal.merge(


### PR DESCRIPTION
The purposes of this micro PR are:

- Remove the confusion from reading the `sensor.md` and seeing the `enum` type being used for the LoginStore instead of `struct` which shall be much more reasonable in this case. 
- Make the `LoginStore` look similar to other store classes like `DemoTableStore` or `DetailStore` that are defined as structs