### PR TITLE
Empty Effects set returned by reducer cancels running effects 

### DIFF
--- a/Sensor/Sources/Driver+Reducible.swift
+++ b/Sensor/Sources/Driver+Reducible.swift
@@ -151,6 +151,13 @@ extension ReducibleStateWithEffects {
     
     private static func reducer(state: StateAndEffects<Self>, event: Event) -> StateAndEffects<Self> {
         let reduced = state.state.reduce(event: event)
+        
+        guard !reduced.effects.isEmpty else {
+            // if effects set is empty we will return the previous effects set to keep them alive
+            return StateAndEffects<Self>(state: reduced.state, effects: state.effects)
+        }
+        
+        // If a running effect is not in 'reduced.effects' it will be canceled
         return StateAndEffects<Self>(state: reduced.state, effects: reduced.effects)
     }
 }


### PR DESCRIPTION
Currently when returning an empty Set from the `reduce` function `ReducibleStateWithEffects` any effects running will be canceled. 

This is caused by the way RxFeedback is operating. If the effects passed to RxFeedback do not contain a running effect anymore they will be never return and de disposed.

This PR is checking that the effects set returned by the reducer is not empty. If it is empty the already running effects from before will be returned again. This will fortunately not trigger them again as there are checks on RxFeedback preventing this and they are just kept alive. 

So returning `return (self, [])` will not cancel any effect running.

But what if you want to cancel an effect when a certain event comes in? 🤷🏼‍♂️

You can then just return an added effect as this effect will cancel any running effects.
E.g. like this:

```
enum Effect: TriggerableEffect {
    ...
    case cancelRunningEffects

    func trigger(context: Context) -> Signal<Event> {
        switch self {
        ...
        case .cancelRunningEffects:
            return Signal.never()
        }
    }
```

This is my proposal. If you guys have a better idea please discard this PR.